### PR TITLE
Added LicenseeService feature and Fixed Validation for Floating Licenses

### DIFF
--- a/include/netlicensing/licensee.h
+++ b/include/netlicensing/licensee.h
@@ -1,0 +1,58 @@
+#ifndef __LICENSEE_H__
+#define __LICENSEE_H__
+
+#include "netlicensing/entity.h"
+#include "netlicensing/constants.h"
+
+namespace netlicensing 
+{
+	struct DummyProperty : public FlatList<DummyProperty>
+	{
+		void add_property(const std::string& name, const std::string& value) {};
+	};
+
+	struct Licensee : public Entity 
+	{
+	private:
+		bool		active_;
+		std::string number_;
+		std::string product_;
+		std::string name_;
+
+	public:
+
+		// Developer Note: 16/09/16 TechToast
+		//
+		// Due to the way the Mapper and Traversal systems have been implemented
+		// all Entity types are required to have a PropertyType defined. However
+		// at the time of writing, the only pre-defined property I could see was
+		// the Product->Discount property. I guess because Product was the only entity
+		// type to be implemeted until now, this issue hasn't been noticed before.
+		//
+		// I did consider modifying the Product class to fix this, but decided to
+		// restrict my submission to additions only for the time being.
+		//
+		typedef DummyProperty PropertyType;
+
+		Licensee() 
+			: active_(true)
+		{}
+
+		void add_list(std::shared_ptr<PropertyType> ptr) {}		// Dummy method
+		void add_property(const std::string& name, const std::string& value);
+		parameters_type to_parameters_list() const;
+
+		bool			getInUse() const						{ return active_; }
+		std::string		getName() const							{ return name_; }
+		std::string		getNumber() const						{ return number_; }
+		std::string		getProduct() const						{ return product_; }
+
+		void			setActive(bool active)					{ active_  = active; }
+		void			setName(const std::string& name)		{ name_    = name; }
+		void			setNumber(const std::string& number)	{ number_  = number; }
+		void			setProduct(const std::string& product)	{ product_ = product; }
+	};
+
+}
+
+#endif //__LICENSEE_H__

--- a/include/netlicensing/netlicensing.h
+++ b/include/netlicensing/netlicensing.h
@@ -4,6 +4,7 @@
 #include "netlicensing/context.h"
 #include "netlicensing/service.h"
 #include "netlicensing/product.h"
+#include "netlicensing/licensee.h"
 #include "netlicensing/exception.h"
 
 namespace netlicensing {
@@ -12,7 +13,8 @@ class ValidationService {
  public:
   static std::list<ValidationResult> validate(Context& ctx, const std::string& licenseeNumber, 
     const std::string& productNumber = std::string(),
-    const std::string& licenseeName = std::string());
+    const std::string& licenseeName = std::string(),
+	const parameters_type additionalAttributes = parameters_type());
 };
 
 class ProductService {
@@ -21,6 +23,14 @@ public:
   static Product update(Context& ctx, const std::string& productNumber, const Product&);
   static void del(Context& ctx, const std::string& productNumber, bool forceCascade);
   static std::list<Product> list(Context& ctx, const std::string& filter);
+};
+
+class LicenseeService {
+public:
+	static Licensee create(Context& ctx, const Licensee&);
+	static Licensee update(Context& ctx, const std::string& licenseeNumber, const Licensee&);
+	static void del(Context& ctx, const std::string& licenseeNumber, bool forceCascade);
+	static std::list<Licensee> list(Context& ctx, const std::string& filter);
 };
 
 

--- a/src/licensee.cc
+++ b/src/licensee.cc
@@ -1,0 +1,25 @@
+#include "netlicensing/licensee.h"
+
+namespace netlicensing 
+{
+	void Licensee::add_property(const std::string& name, const std::string& value) 
+	{
+		if (name == "number")				assign(number_, value);
+		else if (name == "name")			assign(name_, value);
+		else if (name == "productNumber")	assign(product_, value);
+		else if (name == "active")			assign(active_, value);
+		else Entity::add_property(name, value);
+	}
+
+	parameters_type Licensee::to_parameters_list() const 
+	{
+		parameters_type params;
+		params.push_back(std::make_pair("number", number_));
+		params.push_back(std::make_pair("name", name_));
+		params.push_back(std::make_pair("productNumber", product_));
+		params.push_back(std::make_pair("active", active_ ? "true" : "false"));
+		params.splice(params.end(), Entity::to_parameters_list());
+		return params;
+	}
+
+}

--- a/src/netlicensing.cc
+++ b/src/netlicensing.cc
@@ -5,11 +5,21 @@ namespace netlicensing {
   std::list<ValidationResult> ValidationService::validate(Context& ctx, 
     const std::string& licenseeNumber,
     const std::string& productNumber/* = std::string()*/,
-    const std::string& licenseeName/* = std::string()*/) {
+    const std::string& licenseeName/* = std::string()*/,
+	const parameters_type additionalAttributes) 
+  {
       std::string endpoint = "licensee/" + escape_string(licenseeNumber) + "/validate";
       parameters_type params;
       if (!productNumber.empty()) params.push_back(std::make_pair("productNumber", escape_string(productNumber)));
       if (!licenseeName.empty()) params.push_back(std::make_pair("licenseeName", escape_string(licenseeName)));
+
+	  // Add any additional attributes to the params list
+	  parameters_type::const_iterator paramIt;
+	  for (paramIt = additionalAttributes.begin(); paramIt != additionalAttributes.end(); ++paramIt) 
+	  {
+		  // Escape pair data and add to the params list
+		  params.push_back(std::make_pair(escape_string((*paramIt).first), escape_string((*paramIt).second)));
+	  }
 
       long http_code;
       std::string res = ctx.get(endpoint, params, http_code);
@@ -39,4 +49,22 @@ namespace netlicensing {
     return netlicensing::list<Product>(ctx, filter);
   }
 
+  //
+  // LicenseeService
+  //
+  Licensee LicenseeService::create(Context& ctx, const Licensee& licensee) {
+	  return netlicensing::create(ctx, licensee);
+  }
+
+  Licensee LicenseeService::update(Context& ctx, const std::string& productNumber, const Licensee& licensee) {
+	  return netlicensing::update(ctx, productNumber, licensee);
+  }
+
+  void LicenseeService::del(Context& ctx, const std::string& licenseeNumber, bool forceCascade) {
+	  netlicensing::del<Licensee>(ctx, licenseeNumber, forceCascade);
+  }
+
+  std::list<Licensee> LicenseeService::list(Context& ctx, const std::string& filter) {
+	  return netlicensing::list<Licensee>(ctx, filter);
+  }
 }

--- a/src/service.cc
+++ b/src/service.cc
@@ -1,11 +1,17 @@
 #include "netlicensing/service.h"
 #include "netlicensing/product.h"
+#include "netlicensing/licensee.h"
 
 namespace netlicensing {
 
 template<>
 std::string endpoint<Product>() {
   return std::string("product");
+};
+
+template<>
+std::string endpoint<Licensee>() {
+	return std::string("licensee");
 };
 
 };


### PR DESCRIPTION
I added the ability to pass additional attributes to the licensee validation request. This means it is now possible to validate and check-in and check-out floating licenses which was not previously possible.

I also added a LicenseeService module which was based on the existing ProductService. All licensee REST requests can now be made via the API.

However I did spot a problem with the Mapper class, and provided a note in licensee.h about it.
